### PR TITLE
Try to make this compilable with Arduino IDE and Platform IO

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Implemented Features:
 * Wifi manager with own access point for initial configuration of Wifi and MQTT server (IP: 192.168.4.1, SSID: PvExcess, Pass: PvExcess)
 
 ## Supported devices
-* LILYO TTGO T-Display ESP32 1.14 Inch (240x135 pixel)
+* LILYGO TTGO T-Display ESP32 1.14 Inch (240x135 pixel)
 
 
 ## JSON Format Data

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,32 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+[platformio]
+default_envs = ESP32
+src_dir = SRC/PvExcess
+
+[env]
+monitor_speed = 115200
+upload_speed = 921600
+
+[env:ESP32]
+platform = espressif32
+board = esp32dev
+framework = arduino
+board_build.filesystem = littlefs
+lib_deps =
+    ArduinoOTA
+    https://github.com/knolleary/pubsubclient#2d228f2f862a95846c65a8518c79f48dfc8f188c
+    http://github.com/arduino-libraries/Arduino_JSON#bf29cd0989227b148ce7ec6599eb6125cdb4533c
+    https://github.com/adafruit/Adafruit-ST7735-Library#c2b3a2c0970988b1c65e8fd0e14a23e96e95b662
+    https://github.com/adafruit/Adafruit-GFX-Library#91d916deeb75263582a2456cb211ebdaf06b840b
+    https://github.com/tzapu/WiFiManager#94bb90322bf85de2c9ec592858f20643161bc11f
+    https://github.com/tobiasfaust/ESPHTTPUpdateServer#9546fdadf688d782b80745cdadf986ba1c441c04
+    https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
+lib_ignore=LittleFS_esp32


### PR DESCRIPTION
Hi @crasu,

I try to make a multi IDE project (Arduino IDE and Platform IO)

1. Platform IO does not want to compile the .ino. But I don't want to rename it to .cpp because this will not work with Arduino IDE.
2.  The Index.h holds a variable which holds the webpage. This construct does not look like it is standard c and it will not compile with Platform IO. `const char MAIN_page[] PROGMEM = R"=====(  <H1>My Page</H1>  )====="; `

It seems that you have overcome this problems in [ShineWiFi-S](https://github.com/otti/Growatt_ShineWiFi-S). How did you do that?

Thanks for your help